### PR TITLE
feat: make all profile attributes optional

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ struct AppState {
 
 async fn create_profile(data: web::Data<AppState>, profile: web::Json<Profile>) -> impl Responder {
     let manager = &data.profile_manager;
-    match manager.create(profile.into_inner()) {
+    match manager.save(profile.into_inner()) {
         Ok(_) => HttpResponse::Created().json(manager.get()),
         Err(e) => {
             HttpResponse::InternalServerError().body(format!("Failed to save profile: {}", e))
@@ -40,7 +40,7 @@ async fn delete_profile(data: web::Data<AppState>) -> impl Responder {
 
 async fn update_profile(data: web::Data<AppState>, profile: web::Json<Profile>) -> impl Responder {
     let manager = &data.profile_manager;
-    match manager.update(profile.into_inner()) {
+    match manager.save(profile.into_inner()) {
         Ok(_) => HttpResponse::Ok().json(manager.get()),
         Err(e) => {
             HttpResponse::InternalServerError().body(format!("Failed to update profile: {}", e))

--- a/src/profile/manager.rs
+++ b/src/profile/manager.rs
@@ -5,6 +5,7 @@ use std::sync::RwLock;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Profile {
+    pub alternate_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,6 +82,7 @@ mod tests {
 
     fn sample_profile() -> Profile {
         Profile {
+            alternate_name: "testuser".to_string(),
             first_name: Some("Test".to_string()),
             last_name: Some("User".to_string()),
             company_name: Some("TestCo".to_string()),
@@ -114,6 +116,7 @@ mod tests {
 
         // Update the profile
         let updated_profile = Profile {
+            alternate_name: "testuser".to_string(),
             first_name: Some("Updated".to_string()),
             last_name: Some("New".to_string()),
             company_name: None,


### PR DESCRIPTION
Hi there! This small PR changes the behaviour of the profile API with the following:
- it introduces the `alternate_name` field in the profile. It is a mandatory field.
- all other fields in the user's profile are made optional. This also means that if some fields can be _removed_ after updating. For instance, if the user created a profile with a `company_name`, then updates it with a profile that doesn't contain `company_name`, then this field gets removed.

In a follow up PR later on, I'll implement a "blocking" of the `alternate_name`, i.e. it can be set only when creating a new identity, but not after. It would be safer, since that field isn't supposed to change. It's not urgent though, since the marketplace doesn't really rely on the presence of that field in this server to function.
