### PR TITLE
maint: add kubernetes manifests

### DIFF
--- a/kubernetes/000-profile-namespace.yaml
+++ b/kubernetes/000-profile-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: profile
+  labels:
+    name: profile
+---
+

--- a/kubernetes/005-profile-pvc.yaml
+++ b/kubernetes/005-profile-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: profile-data
+  namespace: profile
+spec:
+  storageClassName: nfs-storageclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---

--- a/kubernetes/010-profile-secret.yaml
+++ b/kubernetes/010-profile-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: profile-secret
+  namespace: profile
+type: Opaque
+data:
+  API_KEY: ${PROFILE_API_KEY}
+---

--- a/kubernetes/020-profile-deployment.yaml
+++ b/kubernetes/020-profile-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: profile
+  namespace: profile
+  labels:
+    app: profile
+spec:
+  selector:
+    matchLabels:
+      app: profile
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: profile
+    spec:
+      containers:
+      - name: profile
+        image: ${PROFILE_IMAGE}:${PROFILE_IMAGETAG}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3005
+          name: api
+        envFrom:
+        - secretRef:
+            name: profile-secret
+        volumeMounts:
+        - name: profile-data
+          mountPath: /app/data/
+      volumes:
+        - name: profile-data
+          persistentVolumeClaim:
+            claimName: profile-data
+      restartPolicy: Always
+---
+

--- a/kubernetes/030-profile-service.yaml
+++ b/kubernetes/030-profile-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: profile
+  namespace: profile
+spec:
+  selector:
+    app: profile
+  type: ClusterIP
+  ports:
+  - name: api
+    protocol: TCP
+    port: 3005
+    targetPort: 3005
+---
+

--- a/kubernetes/040-profile-ingress.yaml
+++ b/kubernetes/040-profile-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: profile-ingress
+  namespace: profile
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls.certresolver: default
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+spec:
+  rules:
+  - host: profile.${PUBLIC_NODE_DOMAIN}
+    http:
+      paths:
+      - path: /profile
+        pathType: Prefix
+        backend:
+          service:
+            name: profile
+            port:
+              number: 3005
+---
+


### PR DESCRIPTION
Hi there! This PR adds some manifests to deploy the profile server in a kubernetes cluster. It isn't generic, but rathe tailored to our (Eviden ARI) specific configuration. Making it more generic would imply:
- parametrizing the storageclass used for the persistent volume
- remove/modify the ingress (assumes Traefik with a custom middleware)

@AlvaroFernandezBejarano A profile server has already been deployed in our Sedimark cluster.